### PR TITLE
docs: Add F# grammar implementation status tracking

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,197 @@
+# F# Grammar Implementation Status
+
+This document tracks the implementation status of F# language features in the tree-sitter-fsharp grammar, mapped against the [F# Language Specification](https://fsharp.org/specs/language-spec/).
+
+## Status Legend
+- ✅ **Implemented** - Feature is fully supported with tests
+- 🚧 **Partial** - Basic support exists but missing some cases  
+- ❌ **Not Implemented** - Feature not yet supported
+- 🔨 **In Progress** - Currently being worked on
+
+## Core Language Features
+
+### Expressions ([Spec §6](https://github.com/fsharp/fslang-spec/blob/main/spec/expressions.md))
+
+| Feature | Status | Tests | Notes |
+|---------|--------|-------|-------|
+| Basic expressions (constants, identifiers) | ✅ | `expr.txt`, `constants.txt` | |
+| Arithmetic/Boolean/String operations | ✅ | `expr.txt`, `operators.txt` | |
+| Tuple expressions | ✅ | `expr.txt` | |
+| List expressions `[1; 2; 3]` | ✅ | `expr.txt` | |
+| Array expressions `[|1; 2; 3|]` | ✅ | `expr.txt` | |
+| Record expressions `{ X = 1 }` | ✅ | `expr.txt` | |
+| Anonymous records `{| X = 1 |}` | ✅ | `expr.txt` | |
+| Sequence expressions `seq { ... }` | 🚧 | `expr.txt:847` | Only basic form, missing yield/for/while |
+| List comprehensions `[ for x in 1..10 -> x ]` | ❌ | | |
+| Array comprehensions | ❌ | | |
+| Computation expressions (full) | 🚧 | `expr.txt:865` | Only async/task with let!/do!, missing custom builders |
+| Query expressions `query { ... }` | ❌ | | LINQ-style queries |
+| Object expressions `{ new IFoo with ... }` | ✅ | `expr.txt:2163` | |
+| Lambda expressions `fun x -> x` | ✅ | `expr.txt:1443` | |
+| Function expressions `function | ... -> ...` | ✅ | `expr.txt:2856` | |
+| Match expressions | ✅ | `expr.txt:2039` | |
+| Try-with/Try-finally | ✅ | `expr.txt:1883` | |
+| If-then-else expressions | ✅ | `expr.txt:1108` | |
+| While loops | ✅ | `expr.txt:2661` | |
+| For loops | ✅ | `expr.txt:1659` | |
+| For-in loops | ✅ | `expr.txt:1659` | |
+| Slice expressions `arr.[1..3]` | ✅ | `expr.txt:2309` | |
+| Wildcard slice expressions `arr.[*]` | ✅ | `expr.txt:3785` | |
+| Quotation expressions `<@ ... @>` | 🚧 | `expr.txt:3199` | Basic support only |
+| Typed quotations `<@ expr : type @>` | ❌ | | |
+| Untyped quotations `<@@ ... @@>` | ❌ | | |
+| Splice expressions `%expr` and `%%expr` | ❌ | | |
+| Lazy expressions `lazy expr` | ❌ | | |
+| Assert expressions | ❌ | | |
+| Address-of expressions `&expr` | 🚧 | `expr.txt:2897` | |
+| Yield expressions `yield expr` | ❌ | | |
+| Yield-bang expressions `yield! expr` | ❌ | | |
+| Return expressions `return expr` | 🚧 | `expr.txt:867` | Only in CE context |
+| Return-bang expressions `return! expr` | ❌ | | |
+| Use expressions `use x = ...` | ❌ | | |
+| Use-bang expressions `use! x = ...` | ❌ | | |
+
+### Patterns ([Spec §7](https://github.com/fsharp/fslang-spec/blob/main/spec/patterns.md))
+
+| Feature | Status | Tests | Notes |
+|---------|--------|-------|-------|
+| Constant patterns | ✅ | `patterns.txt` | |
+| Identifier patterns | ✅ | `patterns.txt` | |
+| Wildcard pattern `_` | ✅ | `patterns.txt` | |
+| As patterns `pat as ident` | ✅ | `patterns.txt:19` | |
+| Or patterns `pat1 | pat2` | ✅ | `patterns.txt:275` | |
+| And patterns `pat1 & pat2` | ✅ | `patterns.txt:443` | |
+| Cons patterns `head :: tail` | ✅ | `patterns.txt:356` | |
+| List patterns `[a; b]` | ✅ | `patterns.txt:107` | |
+| Array patterns `[| a; b |]` | 🚧 | `patterns.txt:290` | Basic only |
+| Record patterns | ✅ | `patterns.txt:163` | |
+| Tuple patterns | ✅ | `patterns.txt:3` | |
+| Type test patterns `:? Type` | 🚧 | `expr.txt:1950` | Basic support |
+| Type annotated patterns | ✅ | `patterns.txt:392` | |
+| Active patterns `(|Even|Odd|)` | 🚧 | `patterns.txt:496` | Basic only, no parameters |
+| Parameterized active patterns | ❌ | | |
+| Partial active patterns `(|Even|_|)` | 🚧 | | Basic support |
+| Null patterns | ✅ | `patterns.txt:140` | |
+| Optional patterns | ✅ | `patterns.txt:214` | |
+| Attribute patterns | ✅ | `patterns.txt:327` | |
+
+### Type Definitions ([Spec §8](https://github.com/fsharp/fslang-spec/blob/main/spec/type-definitions.md))
+
+| Feature | Status | Tests | Notes |
+|---------|--------|-------|-------|
+| Type abbreviations | ✅ | `type_defn.txt` | |
+| Record types | ✅ | `type_defn.txt:140` | |
+| Discriminated unions | ✅ | `type_defn.txt:356` | |
+| Class types | ✅ | `type_defn.txt:951` | |
+| Interface types | ✅ | `type_defn.txt:1759` | |
+| Struct types | ✅ | `type_defn.txt:1913` | |
+| Enum types | ✅ | `type_defn.txt:1969` | |
+| Delegate types | ✅ | `type_defn.txt:2041` | |
+| Exception types | ✅ | `type_defn.txt:2140` | |
+| Type extensions | ✅ | `type_defn.txt:2210` | |
+| Flexible types `#Type` | 🚧 | `expr.txt:2984` | |
+| Static members | 🚧 | | Limited support |
+| Properties (get/set) | 🚧 | | Basic support |
+| Indexers | ❌ | | |
+| Events | ❌ | | |
+| Auto-properties | ❌ | | |
+| Explicit constructors | ✅ | `type_defn.txt` | |
+| Additional constructors | ✅ | `type_defn.txt` | |
+| Generic type parameters | ✅ | `type_defn.txt` | |
+| Type constraints | 🚧 | `type_defn.txt:1584` | Basic support |
+| SRTP constraints | ❌ | | Statically resolved type parameters |
+
+### Type System Features ([Spec §5](https://github.com/fsharp/fslang-spec/blob/main/spec/types-and-type-constraints.md))
+
+| Feature | Status | Tests | Notes |
+|---------|--------|-------|-------|
+| Basic types (int, string, etc.) | ✅ | Throughout | |
+| Function types `'a -> 'b` | ✅ | `type_defn.txt` | |
+| Tuple types `'a * 'b` | ✅ | `type_defn.txt` | |
+| Array types `'a[]` | ✅ | `type_defn.txt` | |
+| List types `'a list` | ✅ | `type_defn.txt` | |
+| Option types | ✅ | `type_defn.txt` | |
+| Generic types `List<'a>` | ✅ | `type_defn.txt` | |
+| Anonymous record types | ✅ | `expr.txt:3336` | |
+| Type abbreviations | ✅ | `type_defn.txt` | |
+| Units of measure | ❌ | | `float<kg>`, `int<m/s>` |
+| Type providers | 🚧 | | Very basic support |
+| Byref types | ❌ | | |
+| Native pointer types | ❌ | | |
+
+### Modules and Namespaces ([Spec §10-11](https://github.com/fsharp/fslang-spec/blob/main/spec/namespaces-and-modules.md))
+
+| Feature | Status | Tests | Notes |
+|---------|--------|-------|-------|
+| Namespaces | ✅ | `module.txt` | |
+| Modules | ✅ | `module.txt` | |
+| Nested modules | ✅ | `module.txt:75` | |
+| Module abbreviations | ✅ | `module_abbrev.txt` | |
+| Module signatures (.fsi) | 🚧 | `fsharp_signature/` | Minimal |
+| Open declarations | ✅ | `import.txt` | |
+| AutoOpen attribute | ✅ | `attributes.txt` | |
+| RequireQualifiedAccess | ✅ | `attributes.txt` | |
+
+### Special Features
+
+| Feature | Status | Tests | Notes |
+|---------|--------|-------|-------|
+| Attributes | ✅ | `attributes.txt` | |
+| Compiler directives | ✅ | `compiler_directive.txt` | |
+| FSI directives | ✅ | `fsi_directives.txt` | |
+| XML documentation | ✅ | `comments.txt` | |
+| Preprocessor directives | ✅ | `compiler_directive.txt` | |
+| Inline functions | 🚧 | | Basic parsing |
+| Operator definitions | ✅ | `operators.txt` | |
+| Extension methods | 🚧 | | Via type extensions |
+| Partial application | ✅ | | Via currying |
+
+## Priority for Implementation
+
+### High Priority (Common Usage)
+1. **Sequence/List/Array Comprehensions** - Very common in F# code
+2. **Static Members and Properties** - Essential for OOP interop
+3. **Full Computation Expression support** - Core F# feature
+4. **Active Patterns with Parameters** - Common in domain modeling
+
+### Medium Priority (Important but Less Common)
+5. **Units of Measure** - Scientific/financial domains
+6. **Query Expressions** - LINQ compatibility
+7. **Type Constraints (full)** - Advanced generics
+8. **Quotations (full)** - Metaprogramming
+
+### Lower Priority (Specialized)
+9. **Type Providers** - Data access scenarios
+10. **Events and Delegates** - Mostly for C# interop
+11. **Byref/Pointer types** - Low-level scenarios
+
+## Contributing
+
+When implementing a feature:
+1. Update this document's status
+2. Add tests to appropriate file in `test/corpus/`
+3. Reference the F# spec section in commit messages
+4. Ensure all tests pass with `npx tree-sitter test`
+
+## Test Coverage
+
+Current test corpus files:
+- `attributes.txt` - 264 lines
+- `comments.txt` - 383 lines  
+- `compiler_directive.txt` - 536 lines
+- `constants.txt` - 735 lines
+- `expr.txt` - 3855 lines
+- `fsharp_signature/values.txt` - 26 lines
+- `fsi_directives.txt` - 44 lines
+- `function_defn.txt` - 252 lines
+- `identifiers.txt` - 111 lines
+- `import.txt` - 23 lines
+- `module.txt` - 347 lines
+- `module_abbrev.txt` - 13 lines
+- `operators.txt` - 99 lines
+- `patterns.txt` - 526 lines
+- `scoping.txt` - 284 lines
+- `source_file.txt` - 176 lines
+- `type_defn.txt` - 2717 lines
+
+Total: ~10,400 lines of tests across 345+ test cases

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -28,7 +28,7 @@ This document tracks the implementation status of F# language features in the tr
 | Query expressions `query { ... }` | ❌ | | LINQ-style queries |
 | Object expressions `{ new IFoo with ... }` | ✅ | `expr.txt:2163` | |
 | Lambda expressions `fun x -> x` | ✅ | `expr.txt:1443` | |
-| Function expressions `function | ... -> ...` | ✅ | `expr.txt:2856` | |
+| Function expressions `function \| ... -> ...` | ✅ | `expr.txt:2856` | |
 | Match expressions | ✅ | `expr.txt:2039` | |
 | Try-with/Try-finally | ✅ | `expr.txt:1883` | |
 | If-then-else expressions | ✅ | `expr.txt:1108` | |


### PR DESCRIPTION
## Summary

This PR adds a comprehensive **IMPLEMENTATION_STATUS.md** document that tracks the current state of F# language feature support in the tree-sitter grammar.

## Motivation

Currently, it's difficult for contributors to understand:
- Which F# features are already implemented
- Where to find tests for existing features
- What features are missing and need work
- The relative priority of unimplemented features

## What this adds

The document provides:
- ✅ Complete mapping of 100+ F# language features against the [F# Language Specification](https://fsharp.org/specs/language-spec/)
- 📍 Test file references for verification of existing features
- 🎯 Priority rankings based on real-world usage patterns
- 📊 Clear status indicators (✅ Implemented, 🚧 Partial, ❌ Not Implemented)

## How this helps

1. **For contributors**: Clear roadmap of what needs implementation
2. **For users**: Transparency about current grammar limitations
3. **For maintainers**: Tracking document to update as features are added

## Example entries

```markdown
| Wildcard slice expressions `arr.[*]` | ✅ | `expr.txt:3785` | |
| Sequence expressions `seq { ... }` | 🚧 | `expr.txt:847` | Only basic form, missing yield/for/while |
| Units of measure | ❌ | | `float<kg>`, `int<m/s>` |
```

This is the first of several planned PRs to improve F# grammar coverage. Future PRs will tackle the high-priority missing features identified in this document.