### PR TITLE
feat: Add wildcard slice expression support

### DIFF
--- a/fsharp/grammar.js
+++ b/fsharp/grammar.js
@@ -987,7 +987,7 @@ module.exports = grammar({
         ),
       ),
 
-    slice_range: ($) => choice($._slice_range_special, $._expression, "*"),
+    slice_range: ($) => choice($._slice_range_special, $._expression, alias("*", $.wildcard_slice)),
 
     //
     // Computation expression (END)

--- a/fsharp/src/grammar.json
+++ b/fsharp/src/grammar.json
@@ -3375,8 +3375,13 @@
           "name": "_expression"
         },
         {
-          "type": "STRING",
-          "value": "*"
+          "type": "ALIAS",
+          "content": {
+            "type": "STRING",
+            "value": "*"
+          },
+          "named": true,
+          "value": "wildcard_slice"
         }
       ]
     },

--- a/fsharp/src/node-types.json
+++ b/fsharp/src/node-types.json
@@ -3160,6 +3160,10 @@
         {
           "type": "_expression",
           "named": true
+        },
+        {
+          "type": "wildcard_slice",
+          "named": true
         }
       ]
     }
@@ -4522,11 +4526,11 @@
   },
   {
     "type": "unit",
-    "named": true
+    "named": false
   },
   {
     "type": "unit",
-    "named": false
+    "named": true
   },
   {
     "type": "unmanaged",
@@ -4574,6 +4578,10 @@
   },
   {
     "type": "wildcard_pattern",
+    "named": true
+  },
+  {
+    "type": "wildcard_slice",
     "named": true
   },
   {

--- a/test/corpus/expr.txt
+++ b/test/corpus/expr.txt
@@ -3780,3 +3780,74 @@ let setDefaultColors fg bg sp =
                 (int))))))
       (block_comment
         (block_comment_content)))))
+================================================================================
+Wildcard slice (all elements)
+================================================================================
+
+let all = arr.[*]
+
+--------------------------------------------------------------------------------
+
+(file
+  (declaration_expression
+    (function_or_value_defn
+      (value_declaration_left
+        (identifier_pattern
+          (long_identifier_or_op
+            (identifier))))
+      (index_expression
+        (long_identifier_or_op
+          (identifier))
+        (slice_ranges
+          (slice_range
+            (wildcard_slice)))))))
+
+================================================================================
+2D array row slice
+================================================================================
+
+let row = matrix.[0.., *]
+
+--------------------------------------------------------------------------------
+
+(file
+  (declaration_expression
+    (function_or_value_defn
+      (value_declaration_left
+        (identifier_pattern
+          (long_identifier_or_op
+            (identifier))))
+      (index_expression
+        (long_identifier_or_op
+          (identifier))
+        (slice_ranges
+          (slice_range
+            (const
+              (int)))
+          (slice_range
+            (wildcard_slice)))))))
+
+================================================================================
+2D array column slice  
+================================================================================
+
+let col = matrix.[*, 0..]
+
+--------------------------------------------------------------------------------
+
+(file
+  (declaration_expression
+    (function_or_value_defn
+      (value_declaration_left
+        (identifier_pattern
+          (long_identifier_or_op
+            (identifier))))
+      (index_expression
+        (long_identifier_or_op
+          (identifier))
+        (slice_ranges
+          (slice_range
+            (wildcard_slice))
+          (slice_range
+            (const
+              (int))))))))


### PR DESCRIPTION
## Summary

This PR adds support for wildcard slice expressions (`[*]`) in F# arrays and lists, improving AST clarity for this common slicing pattern.

## Problem

The grammar already parsed `arr.[*]` syntax but didn't create a proper AST node for the wildcard, making it difficult for tools to recognize this as a distinct operation from other slice patterns.

## Solution  

Added an alias for `"*"` as `wildcard_slice` in the `slice_range` rule:
```javascript
// Before
slice_range: ($) => choice($._slice_range_special, $._expression, "*"),

// After
slice_range: ($) => choice($._slice_range_special, $._expression, alias("*", $.wildcard_slice)),
```

## Examples

The following F# code now produces clear AST nodes:
```fsharp
let all = arr.[*]           // Select all elements
let row = matrix.[0.., *]    // Select entire row
let col = matrix.[*, 0..]    // Select entire column  
```

## Tests

Added 3 tests to `test/corpus/expr.txt`:
- Simple wildcard slice
- 2D array row slice with wildcard
- 2D array column slice with wildcard

All existing tests continue to pass.

## Related

This addresses one of the gaps identified in #150 (Implementation Status tracking).