### PR TITLE
Minor updates and CI fix

### DIFF
--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,11 +1,28 @@
-const root = require("path").join(__dirname, "..", "..");
+const path = require("path");
 
-module.exports =
+const root = path.join(__dirname, "..", "..");
+const binding =
   typeof process.versions.bun === "string"
     // Support `bun build --compile` by being statically analyzable enough to find the .node file at build-time
     ? require(`../../prebuilds/${process.platform}-${process.arch}/tree-sitter-fsharp.node`)
     : require("node-gyp-build")(root);
 
 try {
-  module.exports.nodeTypeInfo = require("../../src/node-types.json");
+  binding.fsharp.nodeTypeInfo = require(path.join(
+    root,
+    "fsharp",
+    "src",
+    "node-types.json",
+  ));
 } catch (_) {}
+
+try {
+  binding.signature.nodeTypeInfo = require(path.join(
+    root,
+    "fsharp_signature",
+    "src",
+    "node-types.json",
+  ));
+} catch (_) {}
+
+module.exports = binding;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "tree-sitter-cli": "^0.26.6"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.22.4"
+        "tree-sitter": "^0.25.0"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.0.tgz",
+      "integrity": "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tree-sitter-cli": "^0.26.6"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.22.4"
+    "tree-sitter": "^0.25.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -109,17 +109,16 @@
 
 
 (dot_expression
-  .
-  (_) @variable.member
-  .
-  (_))
+  base: (_) @variable.member
+  field: (long_identifier_or_op
+    (identifier) @property))
 
 (application_expression
   .
   (long_identifier_or_op
     (identifier) @function.call)
   .
-  (_) @variable)
+  (_))
 
 (application_expression
   .
@@ -127,7 +126,7 @@
     field: (long_identifier_or_op
       (identifier) @function.call))
   .
-  (_) @variable)
+  (_))
 
 (application_expression
   .
@@ -136,7 +135,7 @@
       (identifier) @function.call)
     (_))
   .
-  (_) @variable)
+  (_))
 
 (application_expression
   .
@@ -146,7 +145,7 @@
         (identifier) @function.call))
     (_))
   .
-  (_) @variable)
+  (_))
 
 ((infix_expression
   .
@@ -154,14 +153,50 @@
   .
   (infix_op) @operator
   .
-  (_) @function.call
+  (application_expression
+    .
+    (long_identifier_or_op
+      (identifier) @function.call))
   )
  (#eq? @operator "|>")
  )
 
 ((infix_expression
   .
-  (_) @function.call
+  (_)
+  .
+  (infix_op) @operator
+  .
+  (application_expression
+    .
+    (dot_expression
+      field: (long_identifier_or_op
+        (identifier) @function.call)))
+  )
+ (#eq? @operator "|>")
+ )
+
+((infix_expression
+  .
+  (application_expression
+    .
+    (long_identifier_or_op
+      (identifier) @function.call))
+  .
+  (infix_op) @operator
+  .
+  (_)
+  )
+ (#eq? @operator "<|")
+ )
+
+((infix_expression
+  .
+  (application_expression
+    .
+    (dot_expression
+      field: (long_identifier_or_op
+        (identifier) @function.call)))
   .
   (infix_op) @operator
   .

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -4,6 +4,7 @@
   (namespace)
   (named_module)
   (function_or_value_defn)
+  (fun_expression)
 ] @local.scope
 
 (value_declaration_left
@@ -31,3 +32,14 @@
       (_ (_ (_ (_ (_ (_ (identifier) @local.definition))))))
      ])
   ))
+
+(fun_expression
+  (argument_patterns
+    [
+     (_ (identifier) @local.definition)
+     (_ (_ (identifier) @local.definition))
+     (_ (_ (_ (identifier) @local.definition)))
+     (_ (_ (_ (_ (identifier) @local.definition))))
+     (_ (_ (_ (_ (_ (identifier) @local.definition)))))
+     (_ (_ (_ (_ (_ (_ (identifier) @local.definition))))))
+    ]))


### PR DESCRIPTION
Update Tree-sitter component (needed to support the current ABI-15).

Define F# highlight query captures

Tighten dotted-call and member-access captures so function and property highlighting stay consistent, especially around pipeline calls. Also add lambda scopes so local parameter captures can resolve inside fun expressions.

Specifically this was hard before, and better with this commit:
```fsharp
/// Filter people by age
let filterByAge minAge maxAge (people: Person list) =
    people
    |> List.filter (fun p -> p.Age >= minAge && p.Age <= maxAge)
    |> List.sortBy (fun p -> p.Name)
```