### PR TITLE
Consume #if as trivia when the branch starts with a continuation token

### DIFF
--- a/common/scanner.h
+++ b/common/scanner.h
@@ -843,6 +843,24 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
               lexer->result_symbol = DEDENT;
               return true;
             }
+            // Branch content starts with a token that can never begin an
+            // expression or declaration but *continues* the enclosing one
+            // (a fluent-chain '.', a closing bracket, a tuple ','): a
+            // structured branch could not parse it, so consume the directive
+            // line — including the newline and the content line's indent, so
+            // the content continues the previous expression exactly as if
+            // the directive were not there — as inactive trivia, and
+            // remember the stray open so `#else`/`#endif` are consumed
+            // textually too.
+            if (has_content && !valid_symbols[ERROR_SENTINEL] &&
+                (lexer->lookahead == '.' || lexer->lookahead == ')' ||
+                 lexer->lookahead == ']' || lexer->lookahead == '}' ||
+                 lexer->lookahead == ',')) {
+              push_preproc_kind(scanner, PREPROC_STRAY);
+              lexer->mark_end(lexer);
+              lexer->result_symbol = PREPROC_INACTIVE;
+              return true;
+            }
             // Branch content stays at block depth: treat the directive lines
             // as whitespace. The peek already consumed up to the content
             // char, so resume the whitespace loop from there.
@@ -877,6 +895,52 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
           } else {
             if (scanner->indents.size > 0) {
               if (valid_symbols[PREPROC_IF]) {
+                if (!valid_symbols[ERROR_SENTINEL] &&
+                    !is_word_char(lexer->lookahead)) {
+                  // The grammar can adopt the directive here, but peek the
+                  // first branch line: if it starts with a token that can
+                  // never begin an expression or declaration (a fluent-chain
+                  // '.', a match-arm '|', a closing bracket, a tuple ','),
+                  // the structured branch could not parse and would split
+                  // the surrounding construct. Consume the directive line as
+                  // inactive trivia instead: the branch content then parses
+                  // inline as part of the enclosing construct, and a later
+                  // stray `#else` swallows the alternative branch.
+                  while (lexer->lookahead != '\n' && !lexer->eof(lexer)) {
+                    advance(lexer);
+                  }
+                  lexer->mark_end(lexer);
+                  int32_t branch_start = 0;
+                  while (!lexer->eof(lexer)) {
+                    if (lexer->lookahead == '\n' || lexer->lookahead == '\r' ||
+                        lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+                      advance(lexer);
+                    } else if (lexer->lookahead == '/') {
+                      advance(lexer);
+                      if (lexer->lookahead != '/') {
+                        branch_start = '/';
+                        break;
+                      }
+                      while (lexer->lookahead != '\n' && !lexer->eof(lexer)) {
+                        advance(lexer);
+                      }
+                    } else {
+                      branch_start = lexer->lookahead;
+                      break;
+                    }
+                  }
+                  if (branch_start == '.' || branch_start == '|' ||
+                      branch_start == ')' || branch_start == ']' ||
+                      branch_start == '}' || branch_start == ',') {
+                    push_preproc_kind(scanner, PREPROC_STRAY);
+                    lexer->result_symbol = PREPROC_INACTIVE;
+                    return true;
+                  }
+                  // Branch content is expression-shaped: decline, so the
+                  // internal lexer adopts `#if` structurally. (The peek
+                  // advanced past mark_end only; declining returns it all.)
+                  return false;
+                }
                 uint16_t current_indent_length = peek_indent_length(scanner);
                 array_push(&scanner->preprocessor_indents,
                            current_indent_length);

--- a/test/corpus/compiler_directive.txt
+++ b/test/corpus/compiler_directive.txt
@@ -1104,3 +1104,41 @@ let f x =
             pattern: (wildcard_pattern)
             block: (const
               (string))))))))
+
+================================================================================
+stray preproc_if around a fluent chain link
+================================================================================
+
+services
+    .AddAntiforgery()
+#if !DEBUG
+    .AddHttpsRedirection(fun opt -> ())
+#endif
+    .AddRouting()
+
+--------------------------------------------------------------------------------
+
+(file
+  (application_expression
+    (dot_expression
+      base: (application_expression
+        (dot_expression
+          base: (application_expression
+            (long_identifier_or_op
+              (long_identifier
+                (identifier)
+                (identifier)))
+            (unit))
+          (preproc_inactive)
+          field: (long_identifier_or_op
+            (identifier)))
+        (fun_expression
+          (argument_patterns
+            (long_identifier
+              (identifier)))
+          (const
+            (unit))))
+      (preproc_inactive)
+      field: (long_identifier_or_op
+        (identifier)))
+    (unit)))

--- a/test/corpus/compiler_directive.txt
+++ b/test/corpus/compiler_directive.txt
@@ -1106,6 +1106,45 @@ let f x =
               (string))))))))
 
 ================================================================================
+stray preproc_if with negated condition
+================================================================================
+
+let f x =
+    match x with
+#if !DEBUG
+    | 0 -> "release zero"
+#else
+    | 0 -> "debug zero"
+#endif
+    | _ -> "other"
+
+--------------------------------------------------------------------------------
+
+(file
+  (declaration_expression
+    (function_or_value_defn
+      (function_declaration_left
+        (identifier)
+        (argument_patterns
+          (long_identifier
+            (identifier))))
+      body: (match_expression
+        (long_identifier_or_op
+          (identifier))
+        (preproc_inactive)
+        (rules
+          (rule
+            pattern: (const
+              (int))
+            block: (const
+              (string))
+            (preproc_inactive))
+          (rule
+            pattern: (wildcard_pattern)
+            block: (const
+              (string))))))))
+
+================================================================================
 stray preproc_if around a fluent chain link
 ================================================================================
 


### PR DESCRIPTION
Follow-up to #204. Real-world code wraps *links of a fluent method chain* in directives:

```fsharp
services
    .AddAntiforgery()
#if !DEBUG
    .AddHttpsRedirection(fun opt -> ())
#endif
    .AddRouting()
```

Here #204's fallback never kicked in: `PREPROC_IF` is valid at the argument position, so the grammar adopted the directive structurally — and then the branch content starting with `.` cannot parse as a standalone expression, leaving `ERROR` nodes inside the chain.

## Change

When the scanner peeks past a `#if` line and the first branch token is one that can never *begin* an expression or declaration but only *continue* the enclosing one — `.` `)` `]` `}` `,` — it now consumes the directive line as a stray `preproc_inactive` instead of letting the grammar adopt it. The token includes the newline and the content line's indentation, so the content continues the previous expression exactly as if the directive were not there; the existing stray machinery from #204 then consumes the matching `#else`/`#endif` textually.

Applied at both decision points: the dedent-lookahead path (which was intercepting the chain case) and ahead of structured adoption inside indented blocks. This is not a heuristic in the fuzzy sense — those five tokens are *provably* unable to start a structured branch, so structured adoption was guaranteed to fail.

Also includes the "stray `#if` with negated condition" corpus test that just missed the #204 squash.

## Verification

- All 461 existing tests pass, plus 2 new corpus tests (fluent chain link, negated condition) → 463/463.
- 529 real-world files (FsAutoComplete, SQLProvider, FSharp.Data, FSharpx.Extras) and the 165-file local repro corpus parse identically before and after.
- Scanner-only change: no grammar edit, no regeneration, parser size and STATE_COUNT untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)