### PR TITLE
Do not anchor INDENT to a block comment trailing the line

### DIFF
--- a/common/scanner.h
+++ b/common/scanner.h
@@ -1471,7 +1471,13 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
 
   if (valid_symbols[INDENT] && !valid_symbols[ERROR_SENTINEL] &&
       !found_bracket_end && !found_preprocessor_end &&
-      !found_same_line_pipe_infix) {
+      !found_same_line_pipe_infix &&
+      // A block comment trailing the current line must not anchor the new
+      // block: without this, `let f x = (* c *)` + an indented body pushes
+      // the comment's column, and the body line immediately DEDENTs it back
+      // out. Decline instead; after the comment is consumed as an extra, the
+      // re-scan crosses the newline and INDENT anchors to the body line.
+      !(found_comment_start && !found_end_of_line)) {
     push_indent(scanner, indent_length, INDENT_NORMAL);
     lexer->result_symbol = INDENT;
     return true;

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -404,3 +404,66 @@ let x = 1
             (identifier))))
       body: (const
         (int)))))
+
+================================================================================
+block comment trailing a line that opens an indented block
+================================================================================
+
+let f x = (* c *)
+    x + 1
+
+--------------------------------------------------------------------------------
+
+(file
+  (declaration_expression
+    (function_or_value_defn
+      (function_declaration_left
+        (identifier)
+        (argument_patterns
+          (long_identifier
+            (identifier))))
+      (block_comment
+        (block_comment_content))
+      body: (infix_expression
+        (long_identifier_or_op
+          (identifier))
+        (infix_op)
+        (const
+          (int))))))
+
+================================================================================
+block comment trailing a match arm arrow
+================================================================================
+
+let f x =
+    match x with
+    | 1 ->
+        "one"
+    | _ -> (* c *)
+        "other"
+
+--------------------------------------------------------------------------------
+
+(file
+  (declaration_expression
+    (function_or_value_defn
+      (function_declaration_left
+        (identifier)
+        (argument_patterns
+          (long_identifier
+            (identifier))))
+      body: (match_expression
+        (long_identifier_or_op
+          (identifier))
+        (rules
+          (rule
+            pattern: (const
+              (int))
+            block: (const
+              (string)))
+          (rule
+            pattern: (wildcard_pattern)
+            (block_comment
+              (block_comment_content))
+            block: (const
+              (string))))))))


### PR DESCRIPTION
A block comment trailing a line that opens an indented block corrupted the tree in every context:

```fsharp
let f x = (* c *)
    x + 1
```

```fsharp
    | _ -> (* "FITestEvent" *)
        Logari.Message.eventError "..."
```

The scanner emitted the body-block `INDENT` anchored to the *comment's* column (mid-line), so the actual body line — at a lower column — immediately emitted `DEDENT` and closed a block containing only the comment, leaving a zero-width `MISSING identifier` and the body escaping its construct (e.g. a match-arm body re-parsed as an application argument outside the match).

Line comments were already handled — the `NEWLINE` emission checks `found_comment_start` — but the `INDENT` emission missed the equivalent guard for a comment trailing the current line. One-line fix: decline INDENT when `found_comment_start && !found_end_of_line`; the comment is then consumed as an extra and the re-scan crosses the newline, anchoring INDENT to the body line as usual. A comment at the *start* of the next line (`found_end_of_line` true) keeps today's behavior.

Scanner-only: no grammar change, `parser.c` untouched.

## Verification

- Full suite green: 465/465 (463 + 2 new corpus tests: trailing comment after `let ... =` and after a match-arm `->`).
- 529 real-world files (FsAutoComplete, SQLProvider, FSharp.Data, FSharpx.Extras) parse identically before and after.
- Found while investigating a 4k-line production file where `| _ -> (* comment *)` was one of the roots of an error cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)