### PR TITLE
Resolve preproc_if module/expression ambiguity statically

### DIFF
--- a/fsharp/grammar.js
+++ b/fsharp/grammar.js
@@ -107,14 +107,8 @@ module.exports = grammar({
   conflicts: ($) => [
     [$.long_identifier, $._identifier_or_op],
     [$.simple_type, $.type_argument],
-    [$._module_elem, $.preproc_if_in_expression],
     [$._module_expression, $._expression],
     [$.declaration_expression, $._comp_or_range_expression],
-    [$.preproc_if_in_expression, $.preproc_if_in_module_body],
-    [$.preproc_else_in_expression, $.preproc_else_in_module_body],
-    [$._module_elem, $.preproc_else_in_expression],
-    [$._module_body_elem, $.preproc_if_in_expression],
-    [$._module_body_elem, $.preproc_else_in_expression],
     [$.rules],
     // Singleton: union_type_cases conflicts with itself (shift the optional
     // _newline before the next '|' case vs. reduce), like [$.rules] above.
@@ -2386,13 +2380,21 @@ module.exports = grammar({
       // Besides expressions, allow body-less let bindings: a branch often
       // ends with `let x = ...` whose body is the code following #endif
       // (the classic `#if INTERACTIVE` pattern).
+      // prec(-3) on the items: at module-body positions the same content
+      // also parses as _module_elem; prefer that statically instead of
+      // declaring a GLR conflict — the split otherwise stays alive for the
+      // whole branch and multiplies version pressure inside module-spanning
+      // directives.
       ($) =>
         repeat(
-          seq(
-            optional($._newline),
-            choice(
-              $._expression,
-              alias($.value_declaration, $.declaration_expression),
+          prec(
+            -3,
+            seq(
+              optional($._newline),
+              choice(
+                $._expression,
+                alias($.value_declaration, $.declaration_expression),
+              ),
             ),
           ),
         ),
@@ -2401,7 +2403,10 @@ module.exports = grammar({
     ...preprocIf(
       "_in_module_body",
       ($) => repeat(seq(optional($._newline), $._module_body_elem)),
-      -2,
+      // -1 (above _in_expression's -2): where both variants apply — inside a
+      // `module X =` body — the module-body variant subsumes expressions, so
+      // prefer it statically rather than keeping a GLR split alive.
+      -1,
     ),
     ...preprocIf(
       "_in_class_definition",

--- a/fsharp/src/grammar.json
+++ b/fsharp/src/grammar.json
@@ -10558,39 +10558,43 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_newline"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
+              "type": "PREC",
+              "value": -3,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
                         "type": "SYMBOL",
-                        "name": "value_declaration"
+                        "name": "_newline"
                       },
-                      "named": true,
-                      "value": "declaration_expression"
-                    }
-                  ]
-                }
-              ]
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expression"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "value_declaration"
+                        },
+                        "named": true,
+                        "value": "declaration_expression"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           },
           {
@@ -10634,39 +10638,43 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_newline"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
+              "type": "PREC",
+              "value": -3,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
                         "type": "SYMBOL",
-                        "name": "value_declaration"
+                        "name": "_newline"
                       },
-                      "named": true,
-                      "value": "declaration_expression"
-                    }
-                  ]
-                }
-              ]
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expression"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "value_declaration"
+                        },
+                        "named": true,
+                        "value": "declaration_expression"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           }
         ]
@@ -10674,7 +10682,7 @@
     },
     "preproc_if_in_module_body": {
       "type": "PREC",
-      "value": -2,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -10748,7 +10756,7 @@
     },
     "preproc_else_in_module_body": {
       "type": "PREC",
-      "value": -2,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -11016,36 +11024,12 @@
       "type_argument"
     ],
     [
-      "_module_elem",
-      "preproc_if_in_expression"
-    ],
-    [
       "_module_expression",
       "_expression"
     ],
     [
       "declaration_expression",
       "_comp_or_range_expression"
-    ],
-    [
-      "preproc_if_in_expression",
-      "preproc_if_in_module_body"
-    ],
-    [
-      "preproc_else_in_expression",
-      "preproc_else_in_module_body"
-    ],
-    [
-      "_module_elem",
-      "preproc_else_in_expression"
-    ],
-    [
-      "_module_body_elem",
-      "preproc_if_in_expression"
-    ],
-    [
-      "_module_body_elem",
-      "preproc_else_in_expression"
     ],
     [
       "rules"

--- a/fsharp_signature/src/grammar.json
+++ b/fsharp_signature/src/grammar.json
@@ -10408,39 +10408,43 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_newline"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
+              "type": "PREC",
+              "value": -3,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
                         "type": "SYMBOL",
-                        "name": "value_declaration"
+                        "name": "_newline"
                       },
-                      "named": true,
-                      "value": "declaration_expression"
-                    }
-                  ]
-                }
-              ]
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expression"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "value_declaration"
+                        },
+                        "named": true,
+                        "value": "declaration_expression"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           },
           {
@@ -10484,39 +10488,43 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_newline"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
+              "type": "PREC",
+              "value": -3,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
                         "type": "SYMBOL",
-                        "name": "value_declaration"
+                        "name": "_newline"
                       },
-                      "named": true,
-                      "value": "declaration_expression"
-                    }
-                  ]
-                }
-              ]
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expression"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "value_declaration"
+                        },
+                        "named": true,
+                        "value": "declaration_expression"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
           }
         ]
@@ -10524,7 +10532,7 @@
     },
     "preproc_if_in_module_body": {
       "type": "PREC",
-      "value": -2,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -10598,7 +10606,7 @@
     },
     "preproc_else_in_module_body": {
       "type": "PREC",
-      "value": -2,
+      "value": -1,
       "content": {
         "type": "SEQ",
         "members": [

--- a/test/corpus/compiler_directive.txt
+++ b/test/corpus/compiler_directive.txt
@@ -826,15 +826,23 @@ let connStr = "b"
 --------------------------------------------------------------------------------
 
 (file
-  (declaration_expression
+  (preproc_if
     (attributes
       (attribute
         (simple_type
           (long_identifier
             (identifier)))))
-    (preproc_if
-      (preproc_if_not_expression
-        (identifier))
+    (preproc_if_not_expression
+      (identifier))
+    (declaration_expression
+      (function_or_value_defn
+        (value_declaration_left
+          (identifier_pattern
+            (long_identifier_or_op
+              (identifier))))
+        (const
+          (string))))
+    (preproc_else
       (declaration_expression
         (function_or_value_defn
           (value_declaration_left
@@ -842,16 +850,7 @@ let connStr = "b"
               (long_identifier_or_op
                 (identifier))))
           (const
-            (string))))
-      (preproc_else
-        (declaration_expression
-          (function_or_value_defn
-            (value_declaration_left
-              (identifier_pattern
-                (long_identifier_or_op
-                  (identifier))))
-            (const
-              (string))))))))
+            (string)))))))
 
 ================================================================================
 preproc_if with dangling let in expression branches


### PR DESCRIPTION
Fixes the catastrophic failure mode where a module-spanning directive turns an entire file into one root `ERROR` node.

## Problem

Real-world files often wrap most of the module in a directive (`#if !NETSTANDARD` ... 4000 lines of controllers ... `#else` ... `#endif`). On a 4183-line production file this produced `(ERROR [0,0] - [4183,0])` with 289 error nodes inside — while the same file with the three directive lines blanked parsed with only 7 localized errors and no root wrap.

Root cause: the grammar declared six GLR conflicts letting the parser hedge between `preproc_if_in_module_body` and `preproc_if_in_expression` (and their `#else` variants). Module elems include expressions, so the two interpretations never disambiguate — the split stays alive for the *entire* branch. Measured on the production file: inside the giant `#if`, token scans run at version_count 6–9 (constantly at tree-sitter's pruning ceiling); the identical content without directives runs at 1–3. Every pruning event risks discarding the continuation that would later accept `#else`/`#endif`; once it does, the unreducible module-spanning `preproc_if` hoists the whole file into a root ERROR.

## Change

Resolve the choice statically instead of hedging:

- demote the `_in_expression` item content (`prec(-3)`) below `_module_elem`
- set `_in_module_body` (−1) above `_in_expression` (−2) where both apply

All six preproc conflicts then become unnecessary (the generator confirms — re-adding one produces an "unnecessary conflict" warning) and are removed. Nothing is lost: at module-body positions the module-body variant subsumes expressions; at true expression positions the module-body variant is not a candidate, so the expression variant still applies.

## Results

- Production file: root wrap gone, 289 → 7 error nodes; version-count distribution inside the branch becomes identical to the directive-free baseline.
- `parser.c` **shrinks** (STATE_COUNT 20374 → 20372, −11 KB).
- 463/463 corpus/highlight/tag tests pass. One expected tree updated (approved): `[<Attr>]` before `#if` now parses as the attributes field of the top-level `preproc_if` — the variant explicitly built for that pattern — instead of a `declaration_expression` wrapping the directive.
- 529 real-world files (FsAutoComplete, SQLProvider, FSharp.Data, FSharpx.Extras) and a 165-file local repro corpus parse byte-identically before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)