### PR TITLE
Record-update continuation fields may sit left of the first field

### DIFF
--- a/fsharp/grammar.js
+++ b/fsharp/grammar.js
@@ -731,7 +731,11 @@ module.exports = grammar({
       seq(
         $._expression,
         "with",
-        scoped($.field_initializers, $._indent, $._dedent),
+        // Brace-kind scope: the fields live inside a literal `{ ... }`, so an
+        // under-indented continuation field must separate (NEWLINE), not close
+        // the scope — `{ q with A = ...;` with the next field left of the
+        // first one is valid F# (the closing `}` bounds the scope).
+        scoped($.field_initializers, $._brace_indent, $._dedent),
       ),
 
     prefixed_expression: ($) =>

--- a/fsharp/src/grammar.json
+++ b/fsharp/src/grammar.json
@@ -2589,7 +2589,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_indent"
+                "name": "_brace_indent"
               },
               {
                 "type": "SYMBOL",

--- a/fsharp_signature/src/grammar.json
+++ b/fsharp_signature/src/grammar.json
@@ -2375,7 +2375,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_indent"
+                "name": "_brace_indent"
               },
               {
                 "type": "SYMBOL",


### PR DESCRIPTION
`{ q with Aliases = ...;` followed by a continuation field indented less than the first field is valid F#: the closing brace bounds the scope, not the column. Give with_field_expression a brace-kind field scope so an under-indented field separates (NEWLINE) instead of dedenting out of the record update mid-expression.