### PR TITLE
Language package specific Readmes. C build fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Node artifacts
 /build/
 /node_modules/
+/.npm-readme-backup
 
 # Swift artifacts
 /.build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-fsharp
         VERSION "0.3.10"
-        DESCRIPTION ""
-        HOMEPAGE_URL "https://github.com/tree-sitter/tree-sitter-fsharp"
+        DESCRIPTION "F# grammars (implementation and signature files) for tree-sitter"
+        HOMEPAGE_URL "https://github.com/ionide/tree-sitter-fsharp"
         LANGUAGES C)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
@@ -17,19 +17,51 @@ endif()
 
 find_program(TREE_SITTER_CLI tree-sitter DOC "Tree-sitter CLI")
 
-add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/parser.c"
-                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/grammar.json"
-                   COMMAND "${TREE_SITTER_CLI}" generate src/grammar.json
-                            --abi=${TREE_SITTER_ABI_VERSION}
-                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-                   COMMENT "Generating parser.c")
+include(GNUInstallDirs)
 
-add_library(tree-sitter-fsharp src/parser.c)
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/scanner.c)
-  target_sources(tree-sitter-fsharp PRIVATE src/scanner.c)
+# This repository defines two grammars: `fsharp` for implementation files and
+# `fsharp_signature` for signature files. Both are generated and compiled into
+# one library — each .c is its own translation unit, so the two scanners'
+# static helpers in common/scanner.h do not collide.
+#
+# The signature grammar is derived from the base one (it starts with
+# `grammar(require("../fsharp/grammar"), ...)`), so it must regenerate whenever
+# either grammar.js changes.
+#
+# The generated sources are checked into git, so the CLI is only needed when a
+# grammar.js is newer than its parser.c. Without it, fall back to the checked-in
+# files rather than failing with a bare `TREE_SITTER_CLI-NOTFOUND` at build time.
+if(TREE_SITTER_CLI)
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/fsharp/src/parser.c"
+                       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/fsharp/grammar.js"
+                       COMMAND "${TREE_SITTER_CLI}" generate
+                                --abi=${TREE_SITTER_ABI_VERSION}
+                       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/fsharp"
+                       COMMENT "Generating fsharp/src/parser.c")
+
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/fsharp_signature/src/parser.c"
+                       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/fsharp_signature/grammar.js"
+                               "${CMAKE_CURRENT_SOURCE_DIR}/fsharp/grammar.js"
+                       COMMAND "${TREE_SITTER_CLI}" generate
+                                --abi=${TREE_SITTER_ABI_VERSION}
+                       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/fsharp_signature"
+                       COMMENT "Generating fsharp_signature/src/parser.c")
+elseif(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/fsharp/src/parser.c"
+       OR NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/fsharp_signature/src/parser.c")
+    message(FATAL_ERROR
+            "The tree-sitter CLI was not found and the generated parsers are missing. "
+            "Install the CLI and reconfigure.")
+else()
+    message(STATUS "tree-sitter CLI not found; using the checked-in generated parsers")
 endif()
+
+add_library(tree-sitter-fsharp
+            fsharp/src/parser.c
+            fsharp/src/scanner.c
+            fsharp_signature/src/parser.c
+            fsharp_signature/src/scanner.c)
 target_include_directories(tree-sitter-fsharp
-                           PRIVATE src
+                           PRIVATE fsharp/src fsharp_signature/src
                            INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bindings/c>
                                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
@@ -44,22 +76,38 @@ set_target_properties(tree-sitter-fsharp
                       SOVERSION "${TREE_SITTER_ABI_VERSION}.${PROJECT_VERSION_MAJOR}"
                       DEFINE_SYMBOL "")
 
+# Placeholders consumed by bindings/c/tree-sitter-fsharp.pc.in. Without these
+# the generated .pc file has an empty prefix, libdir, includedir and Version.
+set(PREFIX "${CMAKE_INSTALL_PREFIX}")
+set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(URL "${PROJECT_HOMEPAGE_URL}")
+set(VERSION "${PROJECT_VERSION}")
+set(REQUIRES "")
+set(ADDITIONAL_LIBS "")
+
 configure_file(bindings/c/tree-sitter-fsharp.pc.in
                "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-fsharp.pc" @ONLY)
-
-include(GNUInstallDirs)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bindings/c/tree_sitter"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         FILES_MATCHING PATTERN "*.h")
+# The .pc file hard-codes -L${libdir}, so it belongs next to the library rather
+# than in the architecture-independent datadir. This matches the Makefile.
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tree-sitter-fsharp.pc"
-        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 install(TARGETS tree-sitter-fsharp
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 file(GLOB QUERIES queries/*.scm)
 install(FILES ${QUERIES}
         DESTINATION "${CMAKE_INSTALL_DATADIR}/tree-sitter/queries/fsharp")
+
+file(GLOB SIGNATURE_QUERIES fsharp_signature/queries/*.scm)
+install(FILES ${SIGNATURE_QUERIES}
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/tree-sitter/queries/fsharp_signature")
 
 add_custom_target(ts-test "${TREE_SITTER_CLI}" test
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ categories = ["parsing", "text-editors"]
 repository = "https://github.com/ionide/tree-sitter-fsharp"
 edition = "2021"
 license = "MIT"
+readme = "bindings/rust/README.md"
 
 build = "bindings/rust/build.rs"
 include = [

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-VERSION := 0.1.0
+VERSION := 0.3.10
 
 LANGUAGE_NAME := tree-sitter-fsharp
 
 # repository
 FSHARP_DIR := fsharp
 SIGNATURE_DIR := fsharp_signature
-SRC_DIR := fsharp/src
 
 PARSER_REPO_URL := $(shell git remote get-url origin 2>/dev/null)
 
@@ -31,11 +30,16 @@ LIBDIR ?= $(PREFIX)/lib
 PCLIBDIR ?= $(LIBDIR)/pkgconfig
 
 # object files
-OBJS := $(patsubst %.c,%.o,$(wildcard grammars/*/src/*.c))
+# Both grammars link into one library. Each .c is its own translation unit, so
+# the two scanners' static helpers in common/scanner.h do not collide, and the
+# exported symbols are namespaced per grammar.
+SRCS := $(FSHARP_DIR)/src/parser.c $(FSHARP_DIR)/src/scanner.c \
+	$(SIGNATURE_DIR)/src/parser.c $(SIGNATURE_DIR)/src/scanner.c
+OBJS := $(SRCS:.c=.o)
 
 # flags
 ARFLAGS := rcs
-override CFLAGS += -I$(SRC_DIR) -std=c11 -fPIC
+override CFLAGS += -I$(FSHARP_DIR)/src -I$(SIGNATURE_DIR)/src -std=c11 -fPIC
 
 # OS-specific bits
 ifeq ($(OS),Windows_NT)
@@ -69,6 +73,11 @@ endif
 
 all: lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT) $(LANGUAGE_NAME).pc
 
+# The real scanner logic lives in the shared header, not in the per-grammar
+# shims, so the implicit .c -> .o rule would otherwise miss edits to it. Keep
+# this below `all` so it does not become the default goal.
+$(FSHARP_DIR)/src/scanner.o $(SIGNATURE_DIR)/src/scanner.o: common/scanner.h
+
 lib$(LANGUAGE_NAME).a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $^
 
@@ -89,20 +98,21 @@ $(LANGUAGE_NAME).pc: bindings/c/$(LANGUAGE_NAME).pc.in
 		-e 's|@PREFIX@|$(PREFIX)|' $< > $@
 
 $(FSHARP_DIR)/src/parser.c: $(FSHARP_DIR)/grammar.js
-	cd $(FSHARP_DIR) && $(TS) generate --no-bindings
+	cd $(FSHARP_DIR) && $(TS) generate
 
 $(SIGNATURE_DIR)/src/parser.c: $(FSHARP_DIR)/grammar.js $(SIGNATURE_DIR)/grammar.js
-	cd $(SIGNATURE_DIR) && $(TS) generate --no-bindings
+	cd $(SIGNATURE_DIR) && $(TS) generate
 
 install: all
-	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(PARSER_NAME) '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
+	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(FSHARP_DIR) '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(SIGNATURE_DIR) '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
 	install -m644 bindings/c/tree_sitter/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
 	install -m644 $(LANGUAGE_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
 	install -m644 lib$(LANGUAGE_NAME).a '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a
 	install -m755 lib$(LANGUAGE_NAME).$(SOEXT) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER)
 	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR)
 	ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT)
-	install -m644 queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(PARSER_NAME)
+	install -m644 queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(FSHARP_DIR)
+	install -m644 $(SIGNATURE_DIR)/queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(SIGNATURE_DIR)
 
 uninstall:
 	$(RM) '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a \
@@ -111,7 +121,8 @@ uninstall:
 		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT) \
 		'$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h \
 		'$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
-	$(RM) -r '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(PARSER_NAME)
+	$(RM) -r '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(FSHARP_DIR) \
+		'$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(SIGNATURE_DIR)
 
 clean:
 	$(RM) $(OBJS) $(LANGUAGE_NAME).pc lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT) lib$(LANGUAGE_NAME).lib

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ tree-sitter grammar for F# (still WIP)
 Based on [the 4.1 F# language specification](https://fsharp.org/specs/language-spec/4.1/FSharpSpec-4.1-latest.pdf) (Mostly, Appendix A)
 and the [F# compiler parser](https://github.com/dotnet/fsharp/blob/main/src/Compiler/pars.fsy)
 
+## Using the grammar
+
+If you just want to *use* the F# parsers rather than work on the grammar, install the
+package for your ecosystem — each has its own usage guide:
+
+| Ecosystem | Package | Guide |
+| --- | --- | --- |
+| Node.js | [npm: `tree-sitter-fsharp`](https://www.npmjs.com/package/tree-sitter-fsharp) | [bindings/node/README.md](./bindings/node/README.md) |
+| Python | [PyPI: `tree-sitter-fsharp`](https://pypi.org/project/tree-sitter-fsharp/) | [bindings/python/README.md](./bindings/python/README.md) |
+| Rust | [crates.io: `tree-sitter-fsharp`](https://crates.io/crates/tree-sitter-fsharp) | [bindings/rust/README.md](./bindings/rust/README.md) |
+| Go | `github.com/ionide/tree-sitter-fsharp/bindings/go` | [bindings/go/README.md](./bindings/go/README.md) |
+| Swift | SwiftPM: `TreeSitterFsharp` | [bindings/swift/README.md](./bindings/swift/README.md) |
+| C | built from source (`make` / CMake) | [bindings/c/README.md](./bindings/c/README.md) |
+| Neovim | via nvim-treesitter | [below](#adding-to-neovim) |
+
+The rest of this README covers building and developing the grammar itself.
+
 ## Getting started
 
 First, run `npm install` to install the `tree-sitter` CLI as a local devDependency (it lands at `node_modules/.bin/tree-sitter`, not on your global `$PATH`).

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -1,0 +1,106 @@
+# tree-sitter-fsharp
+
+F# grammars for [tree-sitter][], built as a C library.
+
+The library exports **two** parsers, both declared in
+[`tree_sitter/tree-sitter-fsharp.h`](tree_sitter/tree-sitter-fsharp.h):
+
+| Function                         | Grammar              | File types    |
+| -------------------------------- | -------------------- | ------------- |
+| `tree_sitter_fsharp()`           | implementation files | `.fs`, `.fsx` |
+| `tree_sitter_fsharp_signature()` | signature files      | `.fsi`        |
+
+Both grammars are compiled into one `libtree-sitter-fsharp`.
+
+## Building
+
+There is no C package on any registry — build from a checkout of the repository. Run the
+commands from the **repository root**, not from this directory.
+
+### Make
+
+```bash
+make
+sudo make install
+```
+
+Honours the usual `PREFIX`, `DESTDIR`, `LIBDIR`, `INCLUDEDIR` and `CC`/`CFLAGS`
+variables. `make install` installs the static and shared libraries, the public header,
+a `tree-sitter-fsharp.pc` pkg-config file, and the query files under
+`$(DATADIR)/tree-sitter/queries/{fsharp,fsharp_signature}`. `make uninstall` reverses it.
+
+The Makefile is POSIX-only and aborts on Windows; use CMake there.
+
+### CMake
+
+```bash
+cmake -B build
+cmake --build build
+cmake --install build
+```
+
+`BUILD_SHARED_LIBS` (default `ON`) selects a shared or static library, and
+`TREE_SITTER_ABI_VERSION` (default `15`) sets the ABI passed to `tree-sitter generate`
+when the checked-in `parser.c` files need regenerating.
+
+Both build systems regenerate `parser.c` from `grammar.js` if it is out of date, which
+needs the [tree-sitter CLI][cli] on `PATH`.
+
+## Usage
+
+The grammars provide only the language functions — you also need the
+[tree-sitter runtime library][runtime] for the parser API itself.
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <tree_sitter/api.h>
+#include <tree_sitter/tree-sitter-fsharp.h>
+
+int main(void) {
+  const char *source = "let x = 1\n";
+
+  TSParser *parser = ts_parser_new();
+  ts_parser_set_language(parser, tree_sitter_fsharp());
+
+  TSTree *tree = ts_parser_parse_string(parser, NULL, source, strlen(source));
+  char *sexp = ts_node_string(ts_tree_root_node(tree));
+  printf("%s\n", sexp);
+
+  free(sexp);
+  ts_tree_delete(tree);
+  ts_parser_delete(parser);
+  return 0;
+}
+```
+
+Signature files need the other grammar — it is a separate parser, not a mode of the first,
+so swap `tree_sitter_fsharp()` for `tree_sitter_fsharp_signature()`.
+
+Compile against the installed pkg-config files:
+
+```bash
+cc example.c $(pkg-config --cflags --libs tree-sitter tree-sitter-fsharp) -o example
+```
+
+`ts_parser_set_language` returns `false` if the runtime's ABI does not match the one the
+parser was generated with; check it in real code.
+
+## Contributing and grammar development
+
+Grammar sources, the test corpus and the development workflow live in the repository:
+see the [main README][repo] and [AGENTS.md][agents]. Bug reports for mis-parsed F# code
+are welcome — reduce the snippet to a minimal example and open an issue or PR.
+
+## License
+
+MIT — see [LICENSE][license].
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[cli]: https://github.com/tree-sitter/tree-sitter/tree/master/crates/cli
+[runtime]: https://github.com/tree-sitter/tree-sitter/tree/master/lib
+[repo]: https://github.com/ionide/tree-sitter-fsharp#readme
+[agents]: https://github.com/ionide/tree-sitter-fsharp/blob/main/AGENTS.md
+[license]: https://github.com/ionide/tree-sitter-fsharp/blob/main/LICENSE

--- a/bindings/c/tree_sitter/tree-sitter-fsharp.h
+++ b/bindings/c/tree_sitter/tree-sitter-fsharp.h
@@ -7,7 +7,11 @@ typedef struct TSLanguage TSLanguage;
 extern "C" {
 #endif
 
+// Implementation files (.fs, .fsx).
 const TSLanguage *tree_sitter_fsharp(void);
+
+// Signature files (.fsi).
+const TSLanguage *tree_sitter_fsharp_signature(void);
 
 #ifdef __cplusplus
 }

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,0 +1,95 @@
+# tree-sitter-fsharp
+
+F# grammars for [tree-sitter][], packaged for Go.
+
+The package ships **two** parsers:
+
+| Function              | Grammar              | File types    |
+| --------------------- | -------------------- | ------------- |
+| `Language()`          | implementation files | `.fs`, `.fsx` |
+| `LanguageSignature()` | signature files      | `.fsi`        |
+
+## Installation
+
+```bash
+go get github.com/ionide/tree-sitter-fsharp/bindings/go
+go get github.com/tree-sitter/go-tree-sitter
+```
+
+The parsers are compiled from the bundled C sources, so **cgo must be enabled** and a C
+compiler must be on `PATH`. Builds with `CGO_ENABLED=0` will fail.
+
+> **Version note.** Releases from 0.3.0 onwards are tagged without the `v` prefix that Go
+> modules require, so the module proxy still resolves `@latest` to `v0.2.0`. Until
+> `v`-prefixed tags are published, pin to a revision to get a newer grammar:
+>
+> ```bash
+> go get github.com/ionide/tree-sitter-fsharp/bindings/go@main
+> ```
+>
+> which records a pseudo-version such as `v0.2.1-0.20250727...`.
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	tree_sitter_fsharp "github.com/ionide/tree-sitter-fsharp/bindings/go"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func main() {
+	parser := tree_sitter.NewParser()
+	defer parser.Close()
+
+	if err := parser.SetLanguage(tree_sitter.NewLanguage(tree_sitter_fsharp.Language())); err != nil {
+		log.Fatalf("error loading F# grammar: %v", err)
+	}
+
+	tree := parser.Parse([]byte("let x = 1\n"), nil)
+	defer tree.Close()
+
+	fmt.Println(tree.RootNode().ToSexp())
+}
+```
+
+Signature files need the other grammar — it is a separate parser, not a mode of the first:
+
+```go
+if err := parser.SetLanguage(tree_sitter.NewLanguage(tree_sitter_fsharp.LanguageSignature())); err != nil {
+	log.Fatalf("error loading F# signature grammar: %v", err)
+}
+
+tree := parser.Parse([]byte("module M\nval x : int\n"), nil)
+```
+
+Both functions return an `unsafe.Pointer` to a `TSLanguage`, which is what
+`tree_sitter.NewLanguage` expects.
+
+## Queries
+
+The Go binding does not embed the query files, but they are part of the module, so `go:embed`
+or a plain read works against the module directory:
+
+- `queries/` — `highlights.scm`, `indents.scm`, `injections.scm`, `locals.scm`, `tags.scm`
+  for the implementation grammar
+- `fsharp_signature/queries/` — `highlights.scm` and `tags.scm` for the signature grammar
+
+## Contributing and grammar development
+
+Grammar sources, the test corpus and the development workflow live in the repository:
+see the [main README][repo] and [AGENTS.md][agents]. Bug reports for mis-parsed F# code
+are welcome — reduce the snippet to a minimal example and open an issue or PR.
+
+## License
+
+MIT — see [LICENSE][license].
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[repo]: https://github.com/ionide/tree-sitter-fsharp#readme
+[agents]: https://github.com/ionide/tree-sitter-fsharp/blob/main/AGENTS.md
+[license]: https://github.com/ionide/tree-sitter-fsharp/blob/main/LICENSE

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -1,0 +1,105 @@
+# tree-sitter-fsharp
+
+F# grammars for [tree-sitter][], packaged for Node.js.
+
+The package ships **two** parsers:
+
+| Export      | Grammar              | File types    |
+| ----------- | -------------------- | ------------- |
+| `fsharp`    | implementation files | `.fs`, `.fsx` |
+| `signature` | signature files      | `.fsi`        |
+
+## Installation
+
+```bash
+npm install tree-sitter-fsharp tree-sitter
+```
+
+`tree-sitter` (the Node runtime, `^0.25.0`) is an optional peer dependency: install it
+alongside this package to parse with the native bindings.
+
+Prebuilt binaries are published for the common platforms and picked up automatically by
+`node-gyp-build`. On any other platform the parsers are compiled from the bundled C
+sources at install time, which requires a C compiler and the usual `node-gyp` toolchain.
+
+## Usage
+
+```js
+const Parser = require("tree-sitter");
+const { fsharp, signature } = require("tree-sitter-fsharp");
+
+const parser = new Parser();
+parser.setLanguage(fsharp);
+
+const tree = parser.parse("let x = 1\n");
+console.log(tree.rootNode.toString());
+```
+
+Signature files need the other grammar — it is a separate parser, not a mode of the first:
+
+```js
+parser.setLanguage(signature);
+const tree = parser.parse("module M\nval x : int\n");
+```
+
+Both exports carry a `nodeTypeInfo` property holding the parsed `node-types.json` for that
+grammar, and TypeScript declarations are included.
+
+## Queries
+
+Highlight, injection, locals and tags queries ship inside the package. Resolve them
+relative to the package root:
+
+```js
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(path.dirname(require.resolve("tree-sitter-fsharp")), "..", "..");
+
+const highlights = fs.readFileSync(path.join(root, "queries", "highlights.scm"), "utf8");
+const sigHighlights = fs.readFileSync(
+  path.join(root, "fsharp_signature", "queries", "highlights.scm"),
+  "utf8",
+);
+```
+
+`queries/` holds `highlights.scm`, `indents.scm`, `injections.scm`, `locals.scm` and
+`tags.scm` for the implementation grammar; `fsharp_signature/queries/` holds
+`highlights.scm` and `tags.scm` for the signature grammar.
+
+## WebAssembly
+
+The published tarball also contains `tree-sitter-fsharp.wasm` and
+`tree-sitter-fsharp_signature.wasm` at the package root, for use with
+[`web-tree-sitter`][web-tree-sitter]. `Parser.init()` must resolve before anything else:
+
+```js
+const { Parser, Language } = require("web-tree-sitter");
+
+await Parser.init();
+const fsharp = await Language.load(
+  require.resolve("tree-sitter-fsharp/tree-sitter-fsharp.wasm"),
+);
+
+const parser = new Parser();
+parser.setLanguage(fsharp);
+```
+
+In a browser bundle, serve the two `.wasm` files as static assets and pass their URLs to
+`Language.load` instead of a filesystem path.
+
+## Contributing and grammar development
+
+Grammar sources, the test corpus and the development workflow live in the repository:
+see the [main README][repo] and [AGENTS.md][agents]. Bug reports for mis-parsed F# code
+are welcome — reduce the snippet to a minimal example and open an issue or PR.
+
+## License
+
+MIT — see [LICENSE][license].
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[web-tree-sitter]: https://www.npmjs.com/package/web-tree-sitter
+[repo]: https://github.com/ionide/tree-sitter-fsharp#readme
+[agents]: https://github.com/ionide/tree-sitter-fsharp/blob/main/AGENTS.md
+[license]: https://github.com/ionide/tree-sitter-fsharp/blob/main/LICENSE

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,78 @@
+# tree-sitter-fsharp
+
+F# grammars for [tree-sitter][], packaged for Python.
+
+The package ships **two** parsers:
+
+| Function               | Grammar              | File types    |
+| ---------------------- | -------------------- | ------------- |
+| `language()`           | implementation files | `.fs`, `.fsx` |
+| `language_signature()` | signature files      | `.fsi`        |
+
+## Installation
+
+```bash
+pip install tree-sitter-fsharp tree-sitter
+```
+
+Requires Python 3.10 or later. The `tree-sitter` runtime (`~=0.24`) is an optional
+dependency, also installable as an extra:
+
+```bash
+pip install "tree-sitter-fsharp[core]"
+```
+
+Wheels are published for the common platforms; other platforms build the extension from
+the bundled C sources, which needs a C11 compiler.
+
+## Usage
+
+```python
+from tree_sitter import Language, Parser
+import tree_sitter_fsharp
+
+parser = Parser(Language(tree_sitter_fsharp.language()))
+
+tree = parser.parse(b"let x = 1\n")
+print(tree.root_node)
+```
+
+Signature files need the other grammar — it is a separate parser, not a mode of the first:
+
+```python
+parser = Parser(Language(tree_sitter_fsharp.language_signature()))
+tree = parser.parse(b"module M\nval x : int\n")
+```
+
+## Queries
+
+Highlight, injection, locals and tags queries ship inside the package and are exposed as
+lazily-read module attributes holding the query source (each is `None` when that query
+file is absent):
+
+```python
+import tree_sitter_fsharp
+
+source = tree_sitter_fsharp.HIGHLIGHTS_QUERY
+```
+
+Available: `HIGHLIGHTS_QUERY`, `INJECTIONS_QUERY`, `LOCALS_QUERY` and `TAGS_QUERY` for the
+implementation grammar, plus `SIGNATURE_HIGHLIGHTS_QUERY` and `SIGNATURE_TAGS_QUERY` for
+the signature grammar.
+
+Type stubs (`py.typed`, `__init__.pyi`) are included.
+
+## Contributing and grammar development
+
+Grammar sources, the test corpus and the development workflow live in the repository:
+see the [main README][repo] and [AGENTS.md][agents]. Bug reports for mis-parsed F# code
+are welcome — reduce the snippet to a minimal example and open an issue or PR.
+
+## License
+
+MIT — see [LICENSE][license].
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[repo]: https://github.com/ionide/tree-sitter-fsharp#readme
+[agents]: https://github.com/ionide/tree-sitter-fsharp/blob/main/AGENTS.md
+[license]: https://github.com/ionide/tree-sitter-fsharp/blob/main/LICENSE

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,0 +1,72 @@
+# tree-sitter-fsharp
+
+F# grammars for the [tree-sitter][] parsing library, packaged as a Rust crate.
+
+The crate ships **two** parsers:
+
+| Constant             | Grammar              | File types    |
+| -------------------- | -------------------- | ------------- |
+| `LANGUAGE_FSHARP`    | implementation files | `.fs`, `.fsx` |
+| `LANGUAGE_SIGNATURE` | signature files      | `.fsi`        |
+
+## Installation
+
+```bash
+cargo add tree-sitter tree-sitter-fsharp
+```
+
+The parsers are compiled from the bundled C sources by `build.rs`, so a C compiler is
+required. The crate itself depends only on `tree-sitter-language` 0.1 and does not pull in
+a runtime, so you choose the `tree-sitter` version; the crate is tested against 0.26.
+
+## Usage
+
+```rust
+let code = r#"
+module M =
+  let x = 0
+"#;
+
+let mut parser = tree_sitter::Parser::new();
+parser
+    .set_language(&tree_sitter_fsharp::LANGUAGE_FSHARP.into())
+    .expect("Error loading F# parser");
+
+let tree = parser.parse(code, None).unwrap();
+assert!(!tree.root_node().has_error());
+```
+
+Signature files need the other grammar — it is a separate parser, not a mode of the first:
+
+```rust
+parser
+    .set_language(&tree_sitter_fsharp::LANGUAGE_SIGNATURE.into())
+    .expect("Error loading F# signature parser");
+
+let tree = parser.parse("module M\nval x : int\n", None).unwrap();
+```
+
+## Queries and node types
+
+Query sources and the static node type descriptions are exposed as `&'static str`
+constants:
+
+- `HIGHLIGHTS_QUERY`, `INJECTIONS_QUERY`, `LOCALS_QUERY`, `TAGS_QUERY`
+- `FSHARP_NODE_TYPES`, `SIGNATURE_NODE_TYPES` — the contents of the respective
+  [`node-types.json`][node-types] files
+
+## Contributing and grammar development
+
+Grammar sources, the test corpus and the development workflow live in the repository:
+see the [main README][repo] and [AGENTS.md][agents]. Bug reports for mis-parsed F# code
+are welcome — reduce the snippet to a minimal example and open an issue or PR.
+
+## License
+
+MIT — see [LICENSE][license].
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[node-types]: https://tree-sitter.github.io/tree-sitter/using-parsers/6-static-node-types.html
+[repo]: https://github.com/ionide/tree-sitter-fsharp#readme
+[agents]: https://github.com/ionide/tree-sitter-fsharp/blob/main/AGENTS.md
+[license]: https://github.com/ionide/tree-sitter-fsharp/blob/main/LICENSE

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -1,0 +1,84 @@
+# tree-sitter-fsharp
+
+F# grammars for [tree-sitter][], packaged as a Swift package.
+
+The `TreeSitterFsharp` target exposes **two** parsers:
+
+| Function                         | Grammar              | File types    |
+| -------------------------------- | -------------------- | ------------- |
+| `tree_sitter_fsharp()`           | implementation files | `.fs`, `.fsx` |
+| `tree_sitter_fsharp_signature()` | signature files      | `.fsi`        |
+
+Both are declared in [`TreeSitterFsharp/fsharp.h`](TreeSitterFsharp/fsharp.h) and compiled
+into a single C target.
+
+## Installation
+
+Add the package to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/ionide/tree-sitter-fsharp", from: "0.3.10"),
+    .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.9.0"),
+],
+targets: [
+    .target(
+        name: "MyTarget",
+        dependencies: [
+            .product(name: "TreeSitterFsharp", package: "tree-sitter-fsharp"),
+            .product(name: "SwiftTreeSitter", package: "swift-tree-sitter"),
+        ]
+    )
+]
+```
+
+`TreeSitterFsharp` is a plain C target and does not depend on a Swift runtime itself —
+pair it with [SwiftTreeSitter][swift-tree-sitter] for the Swift API, as the package's own
+tests do.
+
+## Usage
+
+```swift
+import SwiftTreeSitter
+import TreeSitterFsharp
+
+let parser = Parser()
+try parser.setLanguage(Language(language: tree_sitter_fsharp()))
+
+let tree = parser.parse("let x = 1\n")
+```
+
+Signature files need the other grammar — it is a separate parser, not a mode of the first:
+
+```swift
+try parser.setLanguage(Language(language: tree_sitter_fsharp_signature()))
+let tree = parser.parse("module M\nval x : int\n")
+```
+
+## Queries
+
+`queries/` is declared as a copied resource of the `TreeSitterFsharp` target, so the
+`.scm` files land in the package's resource bundle with their directory structure intact.
+Because the target is C rather than Swift, SwiftPM does not synthesise a `Bundle.module`
+accessor for it; locate the bundle yourself, or vendor the query files you need directly
+from the repository:
+
+- `queries/` — `highlights.scm`, `indents.scm`, `injections.scm`, `locals.scm`, `tags.scm`
+  for the implementation grammar
+- `fsharp_signature/queries/` — `highlights.scm` and `tags.scm` for the signature grammar
+
+## Contributing and grammar development
+
+Grammar sources, the test corpus and the development workflow live in the repository:
+see the [main README][repo] and [AGENTS.md][agents]. Bug reports for mis-parsed F# code
+are welcome — reduce the snippet to a minimal example and open an issue or PR.
+
+## License
+
+MIT — see [LICENSE][license].
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[swift-tree-sitter]: https://github.com/tree-sitter/swift-tree-sitter
+[repo]: https://github.com/ionide/tree-sitter-fsharp#readme
+[agents]: https://github.com/ionide/tree-sitter-fsharp/blob/main/AGENTS.md
+[license]: https://github.com/ionide/tree-sitter-fsharp/blob/main/LICENSE

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tree-sitter-fsharp",
   "version": "0.3.10",
-  "description": "",
+  "description": "F# grammars (implementation and signature files) for tree-sitter",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ionide/tree-sitter-fsharp.git"
@@ -37,6 +37,8 @@
   },
   "scripts": {
     "install": "node-gyp-build",
+    "prepack": "node scripts/npm-readme.js swap",
+    "postpack": "node scripts/npm-readme.js restore",
     "generate": "for dir in fsharp fsharp_signature; do cd $dir; tree-sitter generate; cd -; done",
     "prestart": "tree-sitter build --wasm",
     "start": "tree-sitter playground",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 authors = [{ name = "Nikolaj Sidorenco" }]
 requires-python = ">=3.10"
 license.text = "MIT"
-readme = "README.md"
+readme = "bindings/python/README.md"
 
 [project.urls]
 Homepage = "https://github.com/ionide/tree-sitter-fsharp"

--- a/scripts/npm-readme.js
+++ b/scripts/npm-readme.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// npm renders whatever README.md sits at the root of the published tarball, and has no
+// package.json field to point somewhere else. So `prepack` swaps the Node binding's
+// README into place and `postpack` puts the repository README back.
+//
+// Cargo (`readme` in Cargo.toml) and PyPI (`readme` in pyproject.toml) point at their
+// own binding READMEs directly and need no such dance.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..");
+const repoReadme = path.join(root, "README.md");
+const nodeReadme = path.join(root, "bindings", "node", "README.md");
+// Must NOT be named README*: npm force-includes every README* in the tarball,
+// regardless of the `files` whitelist, and the backup would ship with it.
+const backup = path.join(root, ".npm-readme-backup");
+
+const mode = process.argv[2];
+
+if (mode === "swap") {
+  if (fs.existsSync(backup)) {
+    throw new Error(
+      `${backup} already exists — an earlier pack did not finish. ` +
+        "Restore README.md from it (or from git) and delete the backup.",
+    );
+  }
+  fs.copyFileSync(repoReadme, backup);
+  fs.copyFileSync(nodeReadme, repoReadme);
+} else if (mode === "restore") {
+  if (fs.existsSync(backup)) {
+    fs.copyFileSync(backup, repoReadme);
+    fs.rmSync(backup);
+  }
+} else {
+  throw new Error(`usage: npm-readme.js <swap|restore> (got ${mode ?? "nothing"})`);
+}

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ class BdistWheel(bdist_wheel):
 class EggInfo(egg_info):
     def find_sources(self):
         super().find_sources()
+        self.filelist.include("bindings/python/README.md")
         self.filelist.recursive_include("queries", "*.scm")
         self.filelist.recursive_include("fsharp_signature/queries", "*.scm")
         self.filelist.include("fsharp/src/tree_sitter/*.h")


### PR DESCRIPTION
TLDR: One common Readme.md is not enough. We need package-specific README.md files.

This pull request introduces significant improvements to the build system, packaging, and documentation for the F# Tree-sitter grammar project. The main changes include support for both implementation (`.fs`, `.fsx`) and signature (`.fsi`) file grammars, updates to the build process to handle both grammars in a single library, enhanced installation routines, and new or updated documentation for all supported language bindings (C, Go, Node.js). Additionally, project metadata and repository URLs have been corrected and clarified.

**Build system and packaging enhancements:**

- **Dual grammar support:** Both the implementation and signature grammars are now built and packaged together, with separate parsers for each file type. The build system (CMake and Makefile) has been updated to generate, compile, and install both grammars and their associated query files, ensuring they do not collide and are properly namespaced. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL20-R64) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L34-R42) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R76-R80) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L92-R115) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L114-R125)
- **Improved build and install routines:** The CMake and Makefile scripts now robustly handle regeneration of parsers, installation of all necessary files (including `pkg-config` files and queries for both grammars), and provide better error handling if the `tree-sitter` CLI is missing. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL20-R64) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR79-R111) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R76-R80) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L92-R115)
- **Project metadata updates:** The `CMakeLists.txt`, `Cargo.toml`, and `Makefile` have updated descriptions, homepage URLs, version numbers, and added references to the correct repository and documentation files. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL5-R6) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-L8)

**Documentation and language binding improvements:**

- **New and improved README files:** Comprehensive usage and installation guides have been added or updated for C (`bindings/c/README.md`), Go (`bindings/go/README.md`), and Node.js (`bindings/node/README.md`), covering both grammars, build instructions, and query usage. The main `README.md` now links to these guides and clarifies how to use the grammars in various ecosystems. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R23) [[2]](diffhunk://#diff-f169880ec12127aaa4b671a0f42fba0f6dc40c3303f432c8531e6e3121e70277R1-R106) [[3]](diffhunk://#diff-8c6643c7f8c1f7e3f459eea671567ea7885bb4b2fca9b68c0d60d8a1d5c1bd5eR1-R95) [[4]](diffhunk://#diff-15d15deabfe8c1b01e69bbfc32c79f6937f8ec7d11542257e2e047a6195075a2R1-R105)
- **C header update:** The C binding header now declares both `tree_sitter_fsharp()` and `tree_sitter_fsharp_signature()` functions, making both parsers available to C consumers.

These changes make the project more robust, easier to use in all supported languages, and ready for broader adoption.

**References:**  
[[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL5-R6) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL20-R64) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR79-R111) [[4]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-L8) [[6]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L34-R42) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R76-R80) [[8]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L92-R115) [[9]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L114-R125) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R23) [[11]](diffhunk://#diff-f169880ec12127aaa4b671a0f42fba0f6dc40c3303f432c8531e6e3121e70277R1-R106) [[12]](diffhunk://#diff-0a9ece6f339878ceef4b8d5dbc9dd159fff4292902a99032eb303f55fc3aaea6R10-R15) [[13]](diffhunk://#diff-8c6643c7f8c1f7e3f459eea671567ea7885bb4b2fca9b68c0d60d8a1d5c1bd5eR1-R95) [[14]](diffhunk://#diff-15d15deabfe8c1b01e69bbfc32c79f6937f8ec7d11542257e2e047a6195075a2R1-R105)